### PR TITLE
Add insane mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ attached | true | Attach firewall instances to Aviatrix Gateways
 firewall_username | fwadmin | Default username for administrative account on the firewall. For Check Point firewalls it will always default to admin. Admin is not allowed for other image types. Should not contain special chars.
 ha_gw | true | Set to false to deploy single Aviatrix gateway. When set to false, fw_amount is ignored and only a single NGFW instance is deployed.
 checkpoint_password | Aviatrix#1234 | Default initial password for Check Point, only required when using Check Point image
-insande_mode | false | Set to true to enable Aviatrix insane mode high-performance encryption 
+insane_mode | false | Set to true to enable Aviatrix insane mode high-performance encryption 
 name | null | When this string is set, user defined name is applied to all infrastructure supporting n+1 sets within a same region or other customization
 
 ### Outputs

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ module "transit_firenet_1" {
   version                = "1.0.1"
   cidr                   = "10.1.0.0/20"
   region                 = "East Us"
-  azure_account_name     = "TM-Azure"
+  account_name           = "TM-Azure"
   firewall_image         = "Palo Alto Networks VM-Series Next-Generation Firewall Bundle 1"
   firewall_image_version = "9.1.0"
 }
@@ -37,7 +37,7 @@ module "transit_firenet_1" {
   version                = "1.0.1"
   cidr                   = "10.1.0.0/20"
   region                 = "East Us"
-  azure_account_name     = "TM-Azure"
+  account_name           = "TM-Azure"
   firewall_image         = "Check Point CloudGuard IaaS Single Gateway R80.40 - Bring Your Own License" 
   firewall_image_version = "8040.900294.0593"
 }
@@ -51,7 +51,7 @@ module "transit_firenet_1" {
   version                = "1.0.1"
   cidr                   = "10.1.0.0/20"
   region                 = "East Us"
-  azure_account_name     = "TM-Azure"
+  account_name           = "TM-Azure"
   firewall_image         = "Fortinet FortiGate (BYOL) Next-Generation Firewall"
   firewall_image_version = "6.4.1"
 }
@@ -63,10 +63,10 @@ The following variables are required:
 key | value
 --- | ---
 region | Azure region to deploy the transit VNET in
-azure_account_name | The Azure access account on the Aviatrix controller, under which the controller will deploy this VNET
+account_name | The Azure access account on the Aviatrix controller, under which the controller will deploy this VNET
 cidr | The IP CIDR wo be used to create the VNET
 firewall_image | String for the firewall image to use
-firewall_image_version | String for the firewall image version to use
+
 
 Firewall images
 ```
@@ -86,7 +86,7 @@ The following variables are optional:
 
 key | default | value
 :--- | :--- | :---
-instance_size | Standard_B2ms | Size of the transit gateway instances
+instance_size | Standard_B2ms | Size of the transit gateway instances. **Insane mode requires a minimum Standard_D3_v2 instance size**
 fw_instance_size | Standard_D3_v2 | Size of the firewall instances
 attached | true | Attach firewall instances to Aviatrix Gateways
 firewall_username | fwadmin | Default username for administrative account on the firewall. For Check Point firewalls it will always default to admin. Admin is not allowed for other image types. Should not contain special chars.
@@ -94,6 +94,8 @@ ha_gw | true | Set to false to deploy single Aviatrix gateway. When set to false
 checkpoint_password | Aviatrix#1234 | Default initial password for Check Point, only required when using Check Point image
 insane_mode | false | Set to true to enable Aviatrix insane mode high-performance encryption 
 name | null | When this string is set, user defined name is applied to all infrastructure supporting n+1 sets within a same region or other customization
+egress_enabled | false | Set to true to enable egress inspection on the firewall instances
+inspection_enabled | true | Set to false to disable inspection on the firewall instances
 
 ### Outputs
 This module will return the following objects:

--- a/README.md
+++ b/README.md
@@ -92,6 +92,8 @@ attached | true | Attach firewall instances to Aviatrix Gateways
 firewall_username | fwadmin | Default username for administrative account on the firewall. For Check Point firewalls it will always default to admin. Admin is not allowed for other image types. Should not contain special chars.
 ha_gw | true | Set to false to deploy single Aviatrix gateway. When set to false, fw_amount is ignored and only a single NGFW instance is deployed.
 checkpoint_password | Aviatrix#1234 | Default initial password for Check Point, only required when using Check Point image
+insande_mode | false | Set to true to enable Aviatrix insane mode high-performance encryption 
+name | null | When this string is set, user defined name is applied to all infrastructure supporting n+1 sets within a same region or other customization
 
 ### Outputs
 This module will return the following objects:
@@ -102,6 +104,12 @@ vpc | The created VNET as an object with all of it's attributes. This was create
 transit_gateway | The created Aviatrix transit gateway as an object with all of it's attributes.
 aviatrix_firenet | The created Aviatrix firenet object with all of it's attributes.
 aviatrix_firewall_instance | A list of the created firewall instances and their attributes.
+azure_rg | The name of the Azure resource group that the Aviatrix infrastructure created in
+azure_vnet_name | The name of the Azure vnet created
+firewall_instance_1_nic_name | The name of the NIC of the first firewall
+firewall_instance_2_nic_name | The name of the NIC of the second firewall
+fw_name | A list of the firewall names created
+
 
 #### Azure Infrastructure Created
 

--- a/main.tf
+++ b/main.tf
@@ -19,7 +19,8 @@ resource "aviatrix_transit_gateway" "single" {
   gw_size                = var.instance_size
   vpc_id                 = aviatrix_vpc.default.vpc_id
   account_name           = var.azure_account_name
-  subnet                 = aviatrix_vpc.default.subnets[2].cidr
+  subnet                 = var.insane_mode ? cidrsubnet(aviatrix_vpc.default.cidr, 3, 6) : aviatrix_vpc.default.subnets[0].cidr
+  insane_mode            = var.insane_mode ? true : false
   enable_transit_firenet = true
   connected_transit      = true
 }

--- a/output.tf
+++ b/output.tf
@@ -17,3 +17,24 @@ output "aviatrix_firewall_instance" {
   description = "A list with the created firewall instances and their attributes"
   value       = var.ha_gw ? [aviatrix_firewall_instance.firewall_instance_1[0], aviatrix_firewall_instance.firewall_instance_2[0]] : [aviatrix_firewall_instance.firewall_instance[0]]
 }
+
+
+output "azure_vnet_name" {
+  value = "${split(":", aviatrix_vpc.default.vpc_id)[0]}"
+}
+
+output "azure_rg" {
+  value = "${split(":", aviatrix_vpc.default.vpc_id)[1]}"
+}
+
+output "firewall_instance_1_nic_name" {
+  value = join("", regex("([^\\/]+$)", aviatrix_firewall_instance.firewall_instance_1[0].egress_interface))
+}
+
+output "firewall_instance_2_nic_name" {
+  value = join("", regex("([^\\/]+$)", aviatrix_firewall_instance.firewall_instance_2[0].egress_interface))
+}
+
+output "firewall_name" {
+  value = [for name in aviatrix_firenet.firenet_ha[0].firewall_instance_association.*.instance_id : join("", regex("^(.*?):", name))]
+}

--- a/variables.tf
+++ b/variables.tf
@@ -36,7 +36,7 @@ variable "is_checkpoint" {
 variable "checkpoint_password" {
   description = "Check Point firewall instance password"
   type        = string
-  default     = "#Aviatrix1234"
+  default     = "Aviatrix#1234"
 }
 
 variable "attached" {
@@ -81,22 +81,4 @@ variable "insane_mode" {
   description = "Set to true to enable Aviatrix high performance encryption."
   type        = bool
   default     = false
-}
-
-
-####
-
-variable "controller_ip" {
-  type    = string
-  default = ""
-}
-
-variable "username" {
-  type    = string
-  default = ""
-}
-
-variable "password" {
-  type    = string
-  default = ""
 }

--- a/variables.tf
+++ b/variables.tf
@@ -8,7 +8,7 @@ variable "cidr" {
   type        = string
 }
 
-variable "azure_account_name" {
+variable "account_name" {
   description = "The Azure account name, as known by the Aviatrix controller"
   type        = string
 }
@@ -72,6 +72,19 @@ variable "ha_gw" {
   type        = bool
   default     = true
 }
+
+variable "egress_enabled" {
+  description = "Set to true to enable egress inspection on the firewall instances"
+  type        = bool
+  default     = false
+}
+
+variable "inspection_enabled" {
+  description = "Set to false to disable inspection on the firewall instances"
+  type        = bool
+  default     = true
+}
+
 
 locals {
   is_checkpoint = length(regexall("check", lower(var.firewall_image))) > 0 #Check if fw image contains checkpoint. Needs special handling for the username/password

--- a/variables.tf
+++ b/variables.tf
@@ -36,13 +36,19 @@ variable "is_checkpoint" {
 variable "checkpoint_password" {
   description = "Check Point firewall instance password"
   type        = string
-  default     = "Aviatrix#1234"
+  default     = "#Aviatrix1234"
 }
 
 variable "attached" {
   description = "Boolean to determine if the spawned firewall instances will be attached on creation"
   type        = bool
   default     = true
+}
+
+variable "name" {
+  description = "Custom name for VNETs, gateways, and firewalls"
+  type        = string
+  default     = ""
 }
 
 variable "firewall_image" {
@@ -69,4 +75,28 @@ variable "ha_gw" {
 
 locals {
   is_checkpoint = length(regexall("check", lower(var.firewall_image))) > 0 #Check if fw image contains checkpoint. Needs special handling for the username/password
+}
+
+variable "insane_mode" {
+  description = "Set to true to enable Aviatrix high performance encryption."
+  type        = bool
+  default     = false
+}
+
+
+####
+
+variable "controller_ip" {
+  type    = string
+  default = ""
+}
+
+variable "username" {
+  type    = string
+  default = ""
+}
+
+variable "password" {
+  type    = string
+  default = ""
 }


### PR DESCRIPTION
- Incorporated standard naming conventions
- Enhanced outputs to include azure resource group name, vnet name, firewall NICs, and a list of firewall instance names
- Added variables to control egress and inspection for firewall instances
- Updated README to reflect new capabilities