### PR TITLE
V4.0.3

### DIFF
--- a/.github/workflows/tflint.yml
+++ b/.github/workflows/tflint.yml
@@ -11,4 +11,4 @@ jobs:
     - name: Check out code
       uses: actions/checkout@master
     - name: Lint Terraform
-      uses: actionshub/terraform-lint@master
+      uses: actionshub/terraform-lint@main

--- a/README.md
+++ b/README.md
@@ -134,6 +134,11 @@ tags | null | Map of tags to assign to the gateway.
 enable_multi_tier_transit |	false |	Switch to enable multi tier transit
 egress_static_cidrs | [] | List of egress static CIDRs. Egress is required to be enabled. Example: ["1.171.15.184/32", "1.171.15.185/32"].
 firewall_image_id | | Custom Firewall image ID.
+learned_cidrs_approval_mode | | Learned cidrs approval mode. Defaults to Gateway. Valid values: gateway, connection
+fail_close_enabled | | Set to true to enable fail close
+user_data_1 | | User data for bootstrapping Fortigate and Checkpoint firewalls. (If user_data_2 is not set, this will used for all NGFW instances)
+user_data_2 | | User data for bootstrapping Fortigate and Checkpoint firewalls. (Only used if 2 or more FW instances are deployed, e.g. when ha_gw is true. Applies to "even" fw instances (2,4,6 etc))
+east_west_inspection_excluded_cidrs | | Network List Excluded From East-West Inspection.
 
 ### Outputs
 This module will return the following objects:

--- a/variables.tf
+++ b/variables.tf
@@ -270,6 +270,36 @@ variable "firewall_image_id" {
   default     = null
 }
 
+variable "learned_cidrs_approval_mode" {
+  description = "Learned cidrs approval mode. Defaults to Gateway. Valid values: gateway, connection"
+  type        = string
+  default     = null
+}
+
+variable "fail_close_enabled" {
+  description = "Set to true to enable fail_close"
+  type        = bool
+  default     = null
+}
+
+variable "user_data_1" {
+  description = "User data for bootstrapping Fortigate and Checkpoint firewalls"
+  type        = string
+  default     = null
+}
+
+variable "user_data_2" {
+  description = "User data for bootstrapping Fortigate and Checkpoint firewalls"
+  type        = string
+  default     = ""
+}
+
+variable "east_west_inspection_excluded_cidrs" {
+  description = "Network List Excluded From East-West Inspection."
+  type        = list(string)
+  default     = null
+}
+
 locals {
   is_checkpoint            = length(regexall("check", lower(var.firewall_image))) > 0    #Check if fw image contains checkpoint. Needs special handling for the username/password
   is_palo                  = length(regexall("palo", lower(var.firewall_image))) > 0     #Check if fw image contains palo. Needs special handling for management_subnet (CP & Fortigate null)
@@ -286,4 +316,5 @@ locals {
   bootstrap_storage_name_2 = length(var.bootstrap_storage_name_2) > 0 ? var.bootstrap_storage_name_2 : var.bootstrap_storage_name_1 #If storage 2 name is not provided, fallback to storage name 1.
   storage_access_key_2     = length(var.storage_access_key_2) > 0 ? var.storage_access_key_2 : var.storage_access_key_1             #If storage 1 key is not provided, fallback to storage key 1.
   file_share_folder_2      = length(var.file_share_folder_2) > 0 ? var.file_share_folder_2 : var.file_share_folder_1                #If storage 2 folder is not provided, fallback to folder 1.
+  user_data_2              = length(var.user_data_2) > 0 ? var.user_data_2 : var.user_data_1                                        #If user data 2 name is not provided, fallback to user data 1.
 }


### PR DESCRIPTION
- Support Fail close in Firenet
- Allow NGFW bootstrapping via user_data (FortiGate+Checkpoint)
- Support exclusions to east/west inspection.
- Auto disable inspection when enable_egress_transit_firenet is enabled.
- Add learned_cidrs_approval_mode
- Add logic to disable connected transit when transit firenet egress is enabled (dual transit)